### PR TITLE
feat: improve mobile touch controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,13 +17,15 @@
         </div>
         
         <canvas id="gameCanvas" width="400" height="600"></canvas>
-        
-        <div class="controls">
+
+        <div class="move-controls">
             <button id="leftBtn" class="control-btn">←</button>
-            <button id="shootBtn" class="control-btn shoot">🚀</button>
             <button id="rightBtn" class="control-btn">→</button>
         </div>
-        
+        <div class="shoot-control">
+            <button id="shootBtn" class="control-btn shoot">🚀</button>
+        </div>
+
         <div class="game-info">
             <p>操作方法：</p>
             <p>パソコン：←→キーで移動、スペースで発射</p>

--- a/script.js
+++ b/script.js
@@ -300,34 +300,70 @@ document.addEventListener('keydown', (e) => {
 });
 
 // タッチボタン操作
-document.getElementById('leftBtn').addEventListener('touchstart', (e) => {
+let moveInterval;
+function startMoving(direction) {
+    movePlayer(direction);
+    moveInterval = setInterval(() => movePlayer(direction), 100);
+}
+function stopMoving() {
+    clearInterval(moveInterval);
+}
+
+let shootInterval;
+function startShooting() {
+    shoot();
+    shootInterval = setInterval(shoot, 200);
+}
+function stopShooting() {
+    clearInterval(shootInterval);
+}
+
+const leftBtn = document.getElementById('leftBtn');
+leftBtn.addEventListener('touchstart', (e) => {
     e.preventDefault();
-    if (gameRunning) movePlayer('left');
+    if (gameRunning) startMoving('left');
+});
+leftBtn.addEventListener('mousedown', (e) => {
+    e.preventDefault();
+    if (gameRunning) startMoving('left');
+});
+['touchend', 'touchcancel', 'mouseup', 'mouseleave'].forEach(evt => {
+    leftBtn.addEventListener(evt, (e) => {
+        e.preventDefault();
+        stopMoving();
+    });
 });
 
-document.getElementById('leftBtn').addEventListener('click', (e) => {
+const rightBtn = document.getElementById('rightBtn');
+rightBtn.addEventListener('touchstart', (e) => {
     e.preventDefault();
-    if (gameRunning) movePlayer('left');
+    if (gameRunning) startMoving('right');
+});
+rightBtn.addEventListener('mousedown', (e) => {
+    e.preventDefault();
+    if (gameRunning) startMoving('right');
+});
+['touchend', 'touchcancel', 'mouseup', 'mouseleave'].forEach(evt => {
+    rightBtn.addEventListener(evt, (e) => {
+        e.preventDefault();
+        stopMoving();
+    });
 });
 
-document.getElementById('rightBtn').addEventListener('touchstart', (e) => {
+const shootBtn = document.getElementById('shootBtn');
+shootBtn.addEventListener('touchstart', (e) => {
     e.preventDefault();
-    if (gameRunning) movePlayer('right');
+    if (gameRunning) startShooting();
 });
-
-document.getElementById('rightBtn').addEventListener('click', (e) => {
+shootBtn.addEventListener('mousedown', (e) => {
     e.preventDefault();
-    if (gameRunning) movePlayer('right');
+    if (gameRunning) startShooting();
 });
-
-document.getElementById('shootBtn').addEventListener('touchstart', (e) => {
-    e.preventDefault();
-    if (gameRunning) shoot();
-});
-
-document.getElementById('shootBtn').addEventListener('click', (e) => {
-    e.preventDefault();
-    if (gameRunning) shoot();
+['touchend', 'touchcancel', 'mouseup', 'mouseleave'].forEach(evt => {
+    shootBtn.addEventListener(evt, (e) => {
+        e.preventDefault();
+        stopShooting();
+    });
 });
 
 // リスタートボタン

--- a/style.css
+++ b/style.css
@@ -58,12 +58,18 @@ body {
     aspect-ratio: 400/600;
 }
 
-.controls {
-    margin: 20px 0;
+.move-controls {
+    position: fixed;
+    bottom: 20px;
+    left: 20px;
     display: flex;
-    justify-content: center;
     gap: 20px;
-    flex-wrap: wrap;
+}
+
+.shoot-control {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
 }
 
 .control-btn {
@@ -79,15 +85,16 @@ body {
     box-shadow: 0 5px 15px rgba(0, 255, 0, 0.3);
     user-select: none;
     -webkit-tap-highlight-color: transparent;
+    transform: scale(1.1);
 }
 
 .control-btn:hover {
-    transform: translateY(-2px);
+    transform: scale(1.1) translateY(-2px);
     box-shadow: 0 7px 20px rgba(0, 255, 0, 0.5);
 }
 
 .control-btn:active {
-    transform: translateY(0);
+    transform: scale(1.1);
     box-shadow: 0 3px 10px rgba(0, 255, 0, 0.3);
 }
 
@@ -185,7 +192,7 @@ body {
         padding: 10px 15px;
     }
     
-    .controls {
+    .move-controls {
         gap: 15px;
     }
     


### PR DESCRIPTION
## Summary
- move left/right controls to bottom-left and shoot button to bottom-right
- enlarge control buttons for easier pressing
- allow holding movement buttons to slide and hold shoot to rapid-fire

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b83d0eafcc8330a2475ab853bb7386