### PR TITLE
Improve button responsiveness and enlarge controls

### DIFF
--- a/script.js
+++ b/script.js
@@ -303,7 +303,7 @@ document.addEventListener('keydown', (e) => {
 let moveInterval;
 function startMoving(direction) {
     movePlayer(direction);
-    moveInterval = setInterval(() => movePlayer(direction), 100);
+    moveInterval = setInterval(() => movePlayer(direction), 50);
 }
 function stopMoving() {
     clearInterval(moveInterval);
@@ -312,7 +312,7 @@ function stopMoving() {
 let shootInterval;
 function startShooting() {
     shoot();
-    shootInterval = setInterval(shoot, 200);
+    shootInterval = setInterval(shoot, 100);
 }
 function stopShooting() {
     clearInterval(shootInterval);

--- a/style.css
+++ b/style.css
@@ -81,20 +81,20 @@ body {
     padding: 15px 25px;
     border-radius: 15px;
     cursor: pointer;
-    transition: all 0.3s ease;
+    transition: all 0.15s ease;
     box-shadow: 0 5px 15px rgba(0, 255, 0, 0.3);
     user-select: none;
     -webkit-tap-highlight-color: transparent;
-    transform: scale(1.1);
+    transform: scale(1.2);
 }
 
 .control-btn:hover {
-    transform: scale(1.1) translateY(-2px);
+    transform: scale(1.2) translateY(-2px);
     box-shadow: 0 7px 20px rgba(0, 255, 0, 0.5);
 }
 
 .control-btn:active {
-    transform: scale(1.1);
+    transform: scale(1.2);
     box-shadow: 0 3px 10px rgba(0, 255, 0, 0.3);
 }
 
@@ -150,11 +150,12 @@ body {
     padding: 15px 30px;
     border-radius: 10px;
     cursor: pointer;
-    transition: all 0.3s ease;
+    transition: all 0.15s ease;
+    transform: scale(1.2);
 }
 
 .restart-btn:hover {
-    transform: scale(1.05);
+    transform: scale(1.25);
 }
 
 .hidden {


### PR DESCRIPTION
## Summary
- Enlarge in-game control and restart buttons to 120% scale and shorten transition time for quicker feedback.
- Increase touch control responsiveness by halving movement interval and speeding shooting interval.

## Testing
- `node --check script.js`
- `npx stylelint style.css` *(fails: 403 Forbidden from npm registry)*
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b971069ee88330a8835b2bf753d85f